### PR TITLE
Replace requests with urllib.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ map_id = resp["id"]
 ```python
 from felt_python import upload_file, list_layers
 
-upload_file(
+upload = upload_file(
     map_id=map_id,
     file_path="path/to/file.csv",
     layer_name="My new layer",
 )
-layer_groups = list_layers(map_id)
-layer_id = layer_groups[0]["relationships"]["datasets"]["data"][0]["id"]
+layer_id = upload["layer_id"]
 ```
 
 ### Uploading a Pandas DataFrame

--- a/felt_python/api.py
+++ b/felt_python/api.py
@@ -6,9 +6,6 @@ import os
 import typing
 import urllib.request
 
-from urllib.parse import urljoin
-
-from uritemplate import URITemplate
 
 try:
     import certifi
@@ -21,21 +18,6 @@ from .exceptions import AuthError
 
 
 BASE_URL = "https://felt.com/api/v2/"
-MAPS_TEMPLATE = URITemplate(urljoin(BASE_URL, "maps{/map_id}"))
-LAYERS_TEMPLATE = URITemplate(urljoin(BASE_URL, "maps{/map_id}/layers{/layer_id}"))
-UPLOAD_TEMPLATE = URITemplate(urljoin(BASE_URL, "maps{/map_id}/upload"))
-REFRESH_TEMPLATE = URITemplate(
-    urljoin(BASE_URL, "maps{/map_id}/layers{/layer_id}/refresh")
-)
-UPDATE_STYLE_TEMPLATE = URITemplate(
-    urljoin(BASE_URL, "maps{/map_id}/layers{/layer_id}/update_style")
-)
-ELEMENTS_TEMPLATE = URITemplate(
-    urljoin(BASE_URL, "maps{/map_id}/elements{/element_id}")
-)
-ELEMENT_GROUPS_TEMPLATE = URITemplate(
-    urljoin(BASE_URL, "maps{/map_id}/element_groups{/element_group_id}")
-)
 
 
 def make_request(

--- a/felt_python/elements.py
+++ b/felt_python/elements.py
@@ -2,31 +2,35 @@
 
 import json
 
-from .api import (
-    make_request,
-    ELEMENTS_TEMPLATE,
-    ELEMENT_GROUPS_TEMPLATE,
-)
+from urllib.parse import urljoin
+
+from .api import make_request, BASE_URL
+
+
+MAP_ELEMENTS_TEMPLATE = urljoin(BASE_URL, "maps/{map_id}/elements/")
+ELEMENT_TEMPLATE = urljoin(MAP_ELEMENTS_TEMPLATE, "{element_id}")
+MAP_ELEMENT_GROUPS_TEMPLATE = urljoin(BASE_URL, "maps/{map_id}/element_groups/")
+ELEMENT_GROUP_TEMPLATE = urljoin(MAP_ELEMENT_GROUPS_TEMPLATE, "{element_group_id}")
 
 
 def list_elements(map_id: str, api_token: str | None = None):
     """List all elements on a map"""
     response = make_request(
-        url=ELEMENTS_TEMPLATE.expand(map_id=map_id),
+        url=MAP_ELEMENTS_TEMPLATE.format(map_id=map_id),
         method="GET",
         api_token=api_token,
     )
-    return json.load(response)["data"]
+    return json.load(response)
 
 
 def list_element_groups(map_id: str, api_token: str | None = None):
     """List all element groups on a map"""
     response = make_request(
-        url=ELEMENT_GROUPS_TEMPLATE.expand(map_id=map_id),
+        url=MAP_ELEMENT_GROUPS_TEMPLATE.format(map_id=map_id),
         method="GET",
         api_token=api_token,
     )
-    return json.load(response)["data"]
+    return json.load(response)
 
 
 def list_elements_in_group(
@@ -34,13 +38,13 @@ def list_elements_in_group(
 ):
     """List all elements in a group"""
     response = make_request(
-        url=ELEMENT_GROUPS_TEMPLATE.expand(
+        url=ELEMENT_GROUP_TEMPLATE.format(
             map_id=map_id, element_group_id=element_group_id
         ),
         method="GET",
         api_token=api_token,
     )
-    return json.load(response)["data"]
+    return json.load(response)
 
 
 def post_elements(map_id: str, geojson_feature_collection: dict | str):
@@ -53,16 +57,16 @@ def post_elements(map_id: str, geojson_feature_collection: dict | str):
     if isinstance(geojson_feature_collection, str):
         geojson_feature_collection = json.loads(geojson_feature_collection)
     response = make_request(
-        url=ELEMENTS_TEMPLATE.expand(map_id=map_id),
+        url=MAP_ELEMENTS_TEMPLATE.format(map_id=map_id),
         method="POST",
         json=geojson_feature_collection,
     )
-    return json.load(response)["data"]
+    return json.load(response)
 
 
 def delete_element(map_id: str, element_id: str):
     """Delete an element"""
     make_request(
-        url=ELEMENTS_TEMPLATE.expand(map_id=map_id, element_id=element_id),
+        url=ELEMENT_TEMPLATE.format(map_id=map_id, element_id=element_id),
         method="DELETE",
     )

--- a/felt_python/maps.py
+++ b/felt_python/maps.py
@@ -2,13 +2,19 @@
 
 import json
 
-from .api import make_request, MAPS_TEMPLATE
+from urllib.parse import urljoin
+
+from .api import make_request, BASE_URL
+
+
+MAPS_ENDPOINT = urljoin(BASE_URL, "maps/")
+MAP_TEMPLATE = urljoin(MAPS_ENDPOINT, "{map_id}/")
 
 
 def create_map(api_token: str | None = None, **json_args):
     """Create a new Felt map"""
     response = make_request(
-        url=MAPS_TEMPLATE.expand(),
+        url=MAPS_ENDPOINT,
         method="POST",
         json=json_args,
         api_token=api_token,
@@ -19,7 +25,7 @@ def create_map(api_token: str | None = None, **json_args):
 def delete_map(map_id: str, api_token: str | None = None):
     """Delete a map"""
     make_request(
-        url=MAPS_TEMPLATE.expand(map_id=map_id),
+        url=MAP_TEMPLATE.format(map_id=map_id),
         method="DELETE",
         api_token=api_token,
     )
@@ -28,19 +34,19 @@ def delete_map(map_id: str, api_token: str | None = None):
 def get_map_details(map_id: str, api_token: str | None = None):
     """Get details of a map"""
     response = make_request(
-        url=MAPS_TEMPLATE.expand(map_id=map_id),
+        url=MAP_TEMPLATE.format(map_id=map_id),
         method="GET",
         api_token=api_token,
     )
-    return json.load(response)["data"]
+    return json.load(response)
 
 
 def update_map(map_id: str, new_title: str, api_token: str | None = None):
     """Update a map's details (title only for now)"""
     response = make_request(
-        url=MAPS_TEMPLATE.expand(map_id=map_id),
+        url=MAP_TEMPLATE.format(map_id=map_id),
         method="PATCH",
         json={"title": new_title},
         api_token=api_token,
     )
-    return json.load(response)["data"]
+    return json.load(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "felt-python"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Álvaro Arredondo", email="alvaro@felt.com" },
   { name="Chris Loer", email="chris@felt.com" },
@@ -13,9 +13,7 @@ authors = [
 description = "The official Felt API client library"
 readme = "README.md"
 requires-python = ">=3.6"
-dependencies = [
-  "uritemplate",
-]
+dependencies = []
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/testing_elements.ipynb
+++ b/testing_elements.ipynb
@@ -50,7 +50,7 @@
     "    public_access=\"private\",\n",
     ")\n",
     "map_id = resp[\"id\"]\n",
-    "resp[\"attributes\"][\"url\"]"
+    "resp[\"url\"]"
    ]
   },
   {

--- a/testing_layers.ipynb
+++ b/testing_layers.ipynb
@@ -16,6 +16,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import time\n",
     "\n",
     "from felt_python import (\n",
     "    create_map,\n",
@@ -97,7 +98,7 @@
    "outputs": [],
    "source": [
     "layer_resp = upload_file(map_id, \"tests/fixtures/null-island-points-sample.geojson\", \"The Points Layer\")\n",
-    "layer_id = layer_resp[\"attributes\"][\"first_layer_id\"]"
+    "layer_id = layer_resp[\"layer_id\"]"
    ]
   },
   {
@@ -115,7 +116,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "get_layer_details(map_id, layer_id)"
+    "while get_layer_details(map_id, layer_id)[\"progress\"] < 100:\n",
+    "    print(\"Waiting for layer to finish processing...\")\n",
+    "    time.sleep(5)"
    ]
   },
   {
@@ -157,7 +160,7 @@
    "source": [
     "live_earthquakes_url = \"https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson\"\n",
     "url_upload = upload_url(map_id, live_earthquakes_url, \"Live Earthquakes\")\n",
-    "url_layer_id = url_upload[\"attributes\"][\"first_layer_id\"]"
+    "url_layer_id = url_upload[\"layer_id\"]"
    ]
   },
   {
@@ -177,6 +180,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "while get_layer_details(map_id, url_layer_id)[\"progress\"] < 100:\n",
+    "    print(\"Waiting for layer to finish processing...\")\n",
+    "    time.sleep(5)\n",
     "refresh_url_layer(map_id, url_layer_id)"
    ]
   },
@@ -203,7 +209,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "current_style = get_layer_details(map_id, layer_id)[\"attributes\"][\"style\"]\n",
+    "current_style = get_layer_details(map_id, layer_id)[\"style\"]\n",
     "current_style"
    ]
   },
@@ -315,7 +321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Remove `requests` dependency and instead use standard library `urllib.request` so users don’t need to `pip install`
* Find and fix some instances of `json["data"]` which are no longer up-to-date with current Felt API, just enough to fully test layer uploads

### Test Plan

`pip install -e .` this repo in a bare virtual env and test core map / layer creation:

```Python
from felt_python import create_map, upload_file
response = create_map(
    title="My new map",
    lat=40,
    lon=-3,
    public_access="private",
)
print(response)
map_id = response["id"]

layer_resp = upload_file(map_id, "tests/fixtures/null-island-points-sample.geojson", "The Points Layer")
```

Example output showing it works for binary files: https://felt.com/map/My-new-map-bMn7QutWSiCj1NQUHCFtjC?loc=41.407,-106.578,6.47z