### PR TITLE
Add support for downloading layers

### DIFF
--- a/felt_python/__init__.py
+++ b/felt_python/__init__.py
@@ -16,6 +16,8 @@ from .layers import (
     refresh_url_layer,
     get_layer_details,
     update_layer_style,
+    get_export_link,
+    download_layer,
 )
 from .elements import (
     list_elements,
@@ -50,6 +52,8 @@ __all__ = [
     "refresh_url_layer",
     "get_layer_details",
     "update_layer_style",
+    "get_export_link",
+    "download_layer",
     "AuthError",
     "list_elements",
     "list_element_groups",

--- a/testing_layers.ipynb
+++ b/testing_layers.ipynb
@@ -288,6 +288,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6cc3e80a",
+   "metadata": {},
+   "source": [
+    "# Downloading a layer\n",
+    "\n",
+    "Download the file uploaded layer as a GeoPackage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb3a3b0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from felt_python import download_layer\n",
+    "\n",
+    "download_layer(map_id, layer_id, file_name=\"exported.gpkg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e3574d06-bfbd-46bc-a86e-b70be7167cbf",
    "metadata": {},
    "source": [
@@ -321,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds two new functions:

- `get_export_link`: simply returns the export link for a layer download. May be useful for batching download requests.
- `download_layer`: a more ergonomic alternative, downloads the layer to a file. Takes an optional `file_name` argument -- when not passed, the file is downloaded to the default export name (currently `parsed.gpkg` or `parsed.tiff`) to the current working directory.

Happy to discuss whether this is the right level of abstraction!