### PR TITLE
Aaronfraint/create element group

### DIFF
--- a/felt_python/__init__.py
+++ b/felt_python/__init__.py
@@ -25,6 +25,7 @@ from .elements import (
     list_elements_in_group,
     post_elements,
     delete_element,
+    post_element_group,
 )
 
 __doc__ = """
@@ -60,4 +61,5 @@ __all__ = [
     "list_elements_in_group",
     "post_elements",
     "delete_element",
+    "post_element_group",
 ]

--- a/felt_python/elements.py
+++ b/felt_python/elements.py
@@ -70,3 +70,18 @@ def delete_element(map_id: str, element_id: str):
         url=ELEMENT_TEMPLATE.format(map_id=map_id, element_id=element_id),
         method="DELETE",
     )
+
+
+def post_element_group(
+    map_id: str,
+    json_element: dict | str,
+    api_token: str | None = None,
+):
+    """Post a new element group"""
+    response = make_request(
+        url=MAP_ELEMENT_GROUPS_TEMPLATE.format(map_id=map_id),
+        method="POST",
+        json=json_element,
+        api_token=api_token,
+    )
+    return json.load(response)

--- a/testing_elements.ipynb
+++ b/testing_elements.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,20 +40,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'https://felt.com/map/A-felt-py-map-for-testing-elements-SOLY09ArcSr9ByXktI3Di6SD'"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "resp = create_map(\n",
     "    title=\"A felt-py map for testing elements\",\n",
@@ -76,42 +65,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'type': 'FeatureCollection',\n",
-       " 'features': [{'geometry': {'coordinates': [-3.70379, 40.416775],\n",
-       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
-       "    'type': 'Point'},\n",
-       "   'properties': {'name': 'Madrid',\n",
-       "    'felt:color': '#C93535',\n",
-       "    'felt:id': '9BlB5C1wYTvaWZP3WxkLnYB',\n",
-       "    'felt:locked': False,\n",
-       "    'felt:ordering': 1728582279322499,\n",
-       "    'felt:symbol': 'dot',\n",
-       "    'felt:type': 'Place'},\n",
-       "   'type': 'Feature'},\n",
-       "  {'geometry': {'coordinates': [2.173403, 41.385063],\n",
-       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
-       "    'type': 'Point'},\n",
-       "   'properties': {'name': 'Barcelona',\n",
-       "    'felt:color': '#C93535',\n",
-       "    'felt:id': 'BNBv4Az8Tv6a213d52wS4A',\n",
-       "    'felt:locked': False,\n",
-       "    'felt:ordering': 1728582279324389,\n",
-       "    'felt:symbol': 'dot',\n",
-       "    'felt:type': 'Place'},\n",
-       "   'type': 'Feature'}]}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# GeoJSON with points for Madrid and Barcelona\n",
     "geojson_feature_collection = {\n",
@@ -142,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,31 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'type': 'FeatureCollection',\n",
-       " 'features': [{'geometry': {'coordinates': [2.173403, 41.385063],\n",
-       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
-       "    'type': 'Point'},\n",
-       "   'properties': {'name': 'Barcelona',\n",
-       "    'felt:color': '#0000FF',\n",
-       "    'felt:id': 'BNBv4Az8Tv6a213d52wS4A',\n",
-       "    'felt:locked': False,\n",
-       "    'felt:ordering': 1728582279324389,\n",
-       "    'felt:symbol': 'dot',\n",
-       "    'felt:type': 'Place'},\n",
-       "   'type': 'Feature'}]}"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Update the Barcelona element, making it blue\n",
     "barcelona_element = [el for el in elements[\"features\"] if el[\"properties\"][\"name\"] == \"Barcelona\"][0]\n",
@@ -206,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,44 +153,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'type': 'FeatureCollection',\n",
-       " 'features': [{'geometry': {'coordinates': [-3.70379, 40.416775],\n",
-       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
-       "    'type': 'Point'},\n",
-       "   'properties': {'name': 'Madrid',\n",
-       "    'felt:color': '#C93535',\n",
-       "    'felt:id': '9BlB5C1wYTvaWZP3WxkLnYB',\n",
-       "    'felt:locked': False,\n",
-       "    'felt:ordering': 1728582279322499,\n",
-       "    'felt:parentId': 'QnUapbn9BShyfaG9B2OjLsSC',\n",
-       "    'felt:symbol': 'dot',\n",
-       "    'felt:type': 'Place'},\n",
-       "   'type': 'Feature'},\n",
-       "  {'geometry': {'coordinates': [2.173403, 41.385063],\n",
-       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
-       "    'type': 'Point'},\n",
-       "   'properties': {'name': 'Barcelona',\n",
-       "    'felt:color': '#0000FF',\n",
-       "    'felt:id': 'BNBv4Az8Tv6a213d52wS4A',\n",
-       "    'felt:locked': False,\n",
-       "    'felt:ordering': 1728582279324389,\n",
-       "    'felt:parentId': 'QnUapbn9BShyfaG9B2OjLsSC',\n",
-       "    'felt:symbol': 'dot',\n",
-       "    'felt:type': 'Place'},\n",
-       "   'type': 'Feature'}]}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "element_group_id = response[0][\"id\"]\n",
     "\n",
@@ -275,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/testing_elements.ipynb
+++ b/testing_elements.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,6 +23,7 @@
     "    # list_elements_in_group,\n",
     "    post_elements,\n",
     "    delete_element,\n",
+    "    post_element_group,\n",
     ")\n",
     "\n",
     "os.environ[\"FELT_API_TOKEN\"] = \"<YOUR_API_TOKEN>\""
@@ -39,9 +40,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://felt.com/map/A-felt-py-map-for-testing-elements-SOLY09ArcSr9ByXktI3Di6SD'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resp = create_map(\n",
     "    title=\"A felt-py map for testing elements\",\n",
@@ -64,9 +76,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'FeatureCollection',\n",
+       " 'features': [{'geometry': {'coordinates': [-3.70379, 40.416775],\n",
+       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
+       "    'type': 'Point'},\n",
+       "   'properties': {'name': 'Madrid',\n",
+       "    'felt:color': '#C93535',\n",
+       "    'felt:id': '9BlB5C1wYTvaWZP3WxkLnYB',\n",
+       "    'felt:locked': False,\n",
+       "    'felt:ordering': 1728582279322499,\n",
+       "    'felt:symbol': 'dot',\n",
+       "    'felt:type': 'Place'},\n",
+       "   'type': 'Feature'},\n",
+       "  {'geometry': {'coordinates': [2.173403, 41.385063],\n",
+       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
+       "    'type': 'Point'},\n",
+       "   'properties': {'name': 'Barcelona',\n",
+       "    'felt:color': '#C93535',\n",
+       "    'felt:id': 'BNBv4Az8Tv6a213d52wS4A',\n",
+       "    'felt:locked': False,\n",
+       "    'felt:ordering': 1728582279324389,\n",
+       "    'felt:symbol': 'dot',\n",
+       "    'felt:type': 'Place'},\n",
+       "   'type': 'Feature'}]}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# GeoJSON with points for Madrid and Barcelona\n",
     "geojson_feature_collection = {\n",
@@ -97,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,9 +160,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'FeatureCollection',\n",
+       " 'features': [{'geometry': {'coordinates': [2.173403, 41.385063],\n",
+       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
+       "    'type': 'Point'},\n",
+       "   'properties': {'name': 'Barcelona',\n",
+       "    'felt:color': '#0000FF',\n",
+       "    'felt:id': 'BNBv4Az8Tv6a213d52wS4A',\n",
+       "    'felt:locked': False,\n",
+       "    'felt:ordering': 1728582279324389,\n",
+       "    'felt:symbol': 'dot',\n",
+       "    'felt:type': 'Place'},\n",
+       "   'type': 'Feature'}]}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Update the Barcelona element, making it blue\n",
     "barcelona_element = [el for el in elements[\"features\"] if el[\"properties\"][\"name\"] == \"Barcelona\"][0]\n",
@@ -132,12 +199,83 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Make an element group\n",
+    "\n",
+    "And then add the previously-created elements to the group by assigning a `felt:parentId` property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [{\n",
+    "    \"name\": \"An element group created via the API\",\n",
+    "    \"symbol\": \"dots\",\n",
+    "}]\n",
+    "response = post_element_group(map_id, data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'FeatureCollection',\n",
+       " 'features': [{'geometry': {'coordinates': [-3.70379, 40.416775],\n",
+       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
+       "    'type': 'Point'},\n",
+       "   'properties': {'name': 'Madrid',\n",
+       "    'felt:color': '#C93535',\n",
+       "    'felt:id': '9BlB5C1wYTvaWZP3WxkLnYB',\n",
+       "    'felt:locked': False,\n",
+       "    'felt:ordering': 1728582279322499,\n",
+       "    'felt:parentId': 'QnUapbn9BShyfaG9B2OjLsSC',\n",
+       "    'felt:symbol': 'dot',\n",
+       "    'felt:type': 'Place'},\n",
+       "   'type': 'Feature'},\n",
+       "  {'geometry': {'coordinates': [2.173403, 41.385063],\n",
+       "    'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},\n",
+       "    'type': 'Point'},\n",
+       "   'properties': {'name': 'Barcelona',\n",
+       "    'felt:color': '#0000FF',\n",
+       "    'felt:id': 'BNBv4Az8Tv6a213d52wS4A',\n",
+       "    'felt:locked': False,\n",
+       "    'felt:ordering': 1728582279324389,\n",
+       "    'felt:parentId': 'QnUapbn9BShyfaG9B2OjLsSC',\n",
+       "    'felt:symbol': 'dot',\n",
+       "    'felt:type': 'Place'},\n",
+       "   'type': 'Feature'}]}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "element_group_id = response[0][\"id\"]\n",
+    "\n",
+    "for feature in elements[\"features\"]:\n",
+    "    feature[\"properties\"][\"felt:parentId\"] = element_group_id\n",
+    "\n",
+    "post_elements(map_id, elements)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Delete the Barcelona element"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +301,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -177,9 +315,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Added a function: `post_element_group`

This wraps the `/element_groups` endpoint allowing users to post a new group.

The resulting `id` can be assigned to elements with a `felt:parentId` property, which will cause the element to be added to the group when posted via the API.