### PR TITLE
Bump version to v0.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "felt-python"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="Álvaro Arredondo", email="alvaro@felt.com" },
   { name="Chris Loer", email="chris@felt.com" },


### PR DESCRIPTION
v0.0.4 is [the latest version in PyPi](https://pypi.org/project/felt-python/) and adds a new function to create element groups (see #15)