### PR TITLE
fix: use the live api endpoint for map updating.

### DIFF
--- a/felt_python/maps.py
+++ b/felt_python/maps.py
@@ -9,6 +9,7 @@ from .api import make_request, BASE_URL
 
 MAPS_ENDPOINT = urljoin(BASE_URL, "maps/")
 MAP_TEMPLATE = urljoin(MAPS_ENDPOINT, "{map_id}/")
+MAP_UPDATE_TEMPLATE = urljoin(MAPS_ENDPOINT, "{map_id}/update")
 
 
 def create_map(api_token: str | None = None, **json_args):
@@ -44,8 +45,8 @@ def get_map_details(map_id: str, api_token: str | None = None):
 def update_map(map_id: str, new_title: str, api_token: str | None = None):
     """Update a map's details (title only for now)"""
     response = make_request(
-        url=MAP_TEMPLATE.format(map_id=map_id),
-        method="PATCH",
+        url=MAP_UPDATE_TEMPLATE.format(map_id=map_id),
+        method="POST",
         json={"title": new_title},
         api_token=api_token,
     )

--- a/testing_maps.ipynb
+++ b/testing_maps.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing Elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from felt_python import (\n",
+    "    update_map\n",
+    ")\n",
+    "\n",
+    "os.environ[\"FELT_API_TOKEN\"] = \"<YOUR_API_TOKEN>\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Maps\n",
+    "\n",
+    "Update a map and retrieve its details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = update_map(\n",
+    "    new_title=\"A felt-py map with an update\",\n",
+    "    map_id=\"<YOUR_MAP_ID>\"\n",
+    ")\n",
+    "resp"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
While working on integrating the API.

I just noticed that in the API -- Map Update POST [https://felt.com/api/v2/maps/{map_id}/update](https://felt.com/api/v2/maps/%7Bmap_id%7D/update) but in the Felt Python `update_map()` leverages a PATCH (https://github.com/felt/felt-python/blob/main/felt_python/maps.py#L44) [maps.py](https://github.com/felt/felt-python/blob/main/felt_python/maps.py)


**Example:**

Returns 200
```
curl --location 'https://felt.com/api/v2/maps/[MAP ID]/update' \
--header 'Authorization: Bearer [TOKEN]' \
--header 'Content-Type: application/json' \
--data '{"title": "new title"}'
```

Returns 404 - Route in python package.
```
curl --location --request PATCH 'https://felt.com/api/v2/maps/[MAP ID]' \
--header 'Authorization: Bearer [TOKEN]' \
--header 'Content-Type: application/json' \
--data '{"title": "new title"}'
```