### PR TITLE
Adds Move Map to felt-python

### DIFF
--- a/felt_python/__init__.py
+++ b/felt_python/__init__.py
@@ -4,6 +4,7 @@ from .maps import (
     delete_map,
     get_map_details,
     update_map,
+    move_map
 )
 from .exceptions import AuthError
 from .layers import (

--- a/felt_python/maps.py
+++ b/felt_python/maps.py
@@ -10,6 +10,7 @@ from .api import make_request, BASE_URL
 MAPS_ENDPOINT = urljoin(BASE_URL, "maps/")
 MAP_TEMPLATE = urljoin(MAPS_ENDPOINT, "{map_id}/")
 MAP_UPDATE_TEMPLATE = urljoin(MAPS_ENDPOINT, "{map_id}/update")
+MAP_MOVE_TEMPLATE = urljoin(MAPS_ENDPOINT, "{map_id}/move")
 
 
 def create_map(api_token: str | None = None, **json_args):
@@ -48,6 +49,17 @@ def update_map(map_id: str, new_title: str, api_token: str | None = None):
         url=MAP_UPDATE_TEMPLATE.format(map_id=map_id),
         method="POST",
         json={"title": new_title},
+        api_token=api_token,
+    )
+    return json.load(response)
+
+
+def move_map(map_id: str, project_id: str, api_token: str | None = None):
+    """Update a map's details (title only for now)"""
+    response = make_request(
+        url=MAP_MOVE_TEMPLATE.format(map_id=map_id),
+        method="POST",
+        json={"project_id": project_id},
         api_token=api_token,
     )
     return json.load(response)

--- a/felt_python/maps.py
+++ b/felt_python/maps.py
@@ -55,7 +55,7 @@ def update_map(map_id: str, new_title: str, api_token: str | None = None):
 
 
 def move_map(map_id: str, project_id: str, api_token: str | None = None):
-    """Update a map's details (title only for now)"""
+    """Move a map to a different project"""
     response = make_request(
         url=MAP_MOVE_TEMPLATE.format(map_id=map_id),
         method="POST",

--- a/testing_maps.ipynb
+++ b/testing_maps.ipynb
@@ -19,7 +19,8 @@
     "    create_map,\n",
     "    delete_map,\n",
     "    get_map_details,\n",
-    "    update_map\n",
+    "    update_map,\n",
+    "    move_map\n",
     ")\n",
     "\n",
     "os.environ[\"FELT_API_TOKEN\"] = \"<YOUR_API_TOKEN>\""
@@ -87,6 +88,21 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Moving a map\n",
+    "\n",
+    "You can move a map from one project to another.\n",
+    "\n",
+    "resp = move_map(\n",
+    "    project_id=\"[YOUR PROJECT ID]\",\n",
+    "    map_id=map_id\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -119,7 +135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The recent updates to a Python package involve modifications in `__init__.py` and `maps.py`. In `__init__.py`, the addition of the `move_map` function expands the module’s functionality to include map relocation features. In `maps.py`, a new URL template, `MAP_MOVE_TEMPLATE`, supports this functionality by setting up an endpoint for map movements. Additionally, the `move_map` function has been introduced, enabling the reassignment of maps to different projects through a POST request that uses map ID, project ID, and an optional API token. These changes enhance the API's ability to manage and manipulate map data effectively.